### PR TITLE
Fix: recover e-mail is never revoked.

### DIFF
--- a/casino/app/controllers/casino/Registration.java
+++ b/casino/app/controllers/casino/Registration.java
@@ -281,7 +281,7 @@ public class Registration extends TransportUriGuarantee {
 
 			} else {
 
-				Casino.setRecoveryPasswordCode(email, code);
+				Casino.setRecoveryPasswordCode(email, null);
 
 				// compute hash...
 				String passwordHash = Casino.getHashForPassword(password);


### PR DESCRIPTION
The recover e-mail can be used multiple times.
This fix should revoke the original recover e-mail after the user changes his password successfully.
